### PR TITLE
feat(dimension): add computeInnerDimension and empty padding/margin

### DIFF
--- a/packages/encodable-dimension/src/computeInnerDimension.ts
+++ b/packages/encodable-dimension/src/computeInnerDimension.ts
@@ -1,0 +1,12 @@
+import { Padding } from './types';
+
+export default function computeInnerDimension(
+  width: number,
+  height: number,
+  { top, bottom, left, right }: Padding,
+) {
+  return {
+    width: width - left - right,
+    height: height - top - bottom,
+  };
+}

--- a/packages/encodable-dimension/src/index.ts
+++ b/packages/encodable-dimension/src/index.ts
@@ -1,7 +1,11 @@
 export { default as getTextDimension } from './getTextDimension';
 export { default as getMultipleTextDimensions } from './getMultipleTextDimensions';
 export { default as computeMaxFontSize } from './computeMaxFontSize';
+export { default as computeInnerDimension } from './computeInnerDimension';
 export { mergeMargin, mergePadding } from './mergeMargin';
 export { default as parseLength } from './parseLength';
+
+export const EMPTY_MARGIN = { top: 0, left: 0, bottom: 0, right: 0 };
+export const EMPTY_PADDING = { top: 0, left: 0, bottom: 0, right: 0 };
 
 export * from './types';

--- a/packages/encodable-dimension/test/computeInnerDimension.test.ts
+++ b/packages/encodable-dimension/test/computeInnerDimension.test.ts
@@ -1,0 +1,10 @@
+import { computeInnerDimension } from '../src';
+
+describe('computeInnerDimension(width, height, padding)', () => {
+  it('returns inner dimension', () => {
+    expect(computeInnerDimension(100, 100, { top: 1, bottom: 1, right: 1, left: 1 })).toEqual({
+      width: 98,
+      height: 98,
+    });
+  });
+});


### PR DESCRIPTION
🏆 Enhancements

* Add `computeInnerDimension()` and `EMPTY_PADDING` and `EMPTY_MARGIN`.